### PR TITLE
implement raspc2c.get()

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,15 @@ rasp2c.set('0xa1', '0x11', '0xff', function(err, result) {
   }
 });
 
+// Get the address 0x11 of the I2C device at address 0xa1 on the I2C bus
+rasp2c.get('0xa1', '0x11', function(err, result) {
+  if (err) {
+    console.log(err);
+  } else {
+    console.log(result);
+  }
+});
+
 ````
 
 ## License

--- a/lib/rasp2c.js
+++ b/lib/rasp2c.js
@@ -101,3 +101,22 @@ exports.set = function(device, address, value, callback) {
 		}
 	});
 }
+
+/**
+ * Run i2cget to get a value
+ *
+ * @see man i2cget
+ *
+ * @param device The address of the I2C device
+ * @param address The address to get
+ */
+exports.get = function(device, address, callback) {
+	var cmd = 'i2cget -y ' + i2cbus + ' ' + device + ' ' + address;
+	exec(cmd, function(err, stdout, stderr) {
+		if(err) {
+			callback(err);
+		} else {
+			callback(null, parseInt(stdout));
+		}
+	});
+}


### PR DESCRIPTION
For completeness, implement rasp2c.get() to retrieve one byte of data without having to do additional processing of the response from rasp2c.dump().
